### PR TITLE
Allow Mox to Run On Any Port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,5 @@ RUN bundle update --bundler
 
 ADD . $APP_HOME
 
-CMD ["bundle", "exec", "rackup", "--host", "0.0.0.0", "-p", "9898"]
+ENV PORT=9898
+ENTRYPOINT bundle exec rackup --host 0.0.0.0 -p $PORT

--- a/README.md
+++ b/README.md
@@ -12,7 +12,15 @@ Needless to say, **mox is not intended to be used in production** or any world-f
 
 ## Setup
 If you're using Docker, the simplest way to get started is with `docker-compose up -d`. This will bring up the server itself at port `9898`.
-To use a different port, set the PORT environment variable, e.g. `PORT=8080 docker-compose up -d`.
+To use a different port, set the PORT environment variable, e.g. `PORT=80`. Note that you may also have to expose the new port in the docker-compose.yml file: 
+```
+  mox:
+    image: eliavlavi/mox-server:<version>
+    environment:
+      - "PORT=80"
+    ports:
+      - "80:80"
+```
 
 ## Usage
 NOTE: [mox-ui](https://github.com/eliav-lavi/mox-ui) is recommended for easy manual management of mox. Should you need to call the server API directly (e.g. in a testing scenario), you may use the following abilities.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Needless to say, **mox is not intended to be used in production** or any world-f
 
 ## Setup
 If you're using Docker, the simplest way to get started is with `docker-compose up -d`. This will bring up the server itself at port `9898`.
-To use a different port, set the PORT environment variable, e.g. `PORT=80`. Note that you also have to expose the new port in the docker-compose.yml file: 
+To use a different port, set the PORT environment variable, e.g. `PORT=80`. Note that you have to expose the new port in the docker-compose.yml file: 
 ```
   mox:
     image: eliavlavi/mox-server:<version>

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Needless to say, **mox is not intended to be used in production** or any world-f
 
 ## Setup
 If you're using Docker, the simplest way to get started is with `docker-compose up -d`. This will bring up the server itself at port `9898`.
+To use a different port, set the PORT environment variable, e.g. `PORT=8080 docker-compose up -d`.
 
 ## Usage
 NOTE: [mox-ui](https://github.com/eliav-lavi/mox-ui) is recommended for easy manual management of mox. Should you need to call the server API directly (e.g. in a testing scenario), you may use the following abilities.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Needless to say, **mox is not intended to be used in production** or any world-f
 
 ## Setup
 If you're using Docker, the simplest way to get started is with `docker-compose up -d`. This will bring up the server itself at port `9898`.
-To use a different port, set the PORT environment variable, e.g. `PORT=80`. Note that you may also have to expose the new port in the docker-compose.yml file: 
+To use a different port, set the PORT environment variable, e.g. `PORT=80`. Note that you also have to expose the new port in the docker-compose.yml file: 
 ```
   mox:
     image: eliavlavi/mox-server:<version>


### PR DESCRIPTION
This PR is meant to allow users to raise `mox-server` on any port.
To run mox-server on port <port>: `docker -e PORT=<port> run mox-server`