### PR TITLE
Add an option to store binary data in an endpoint encoded in base64

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -187,7 +187,11 @@ class App < Sinatra::Base
   private def endpoint_return_value(endpoint_id:, params:, body:, storage_client:)
     endpoint_id = Services::EndpointIdComposer.call(id: endpoint_id)
     persisted_endpoint = Models::Endpoint.new(JSON.parse(storage_client.get(key: endpoint_id)))
-    persisted_endpoint.return_value_json(binding)
+    if persisted_endpoint.return_value_binary?
+      persisted_endpoint.return_value_binary
+    else
+      persisted_endpoint.return_value_json(binding)
+    end
   end
 
   def self.deregister_endpoint(endpoint:)

--- a/models/client_error.rb
+++ b/models/client_error.rb
@@ -3,3 +3,4 @@ class InvalidRequest < ClientError; end
 class EndpointIdNotFound < ClientError; end
 class InvalidTemplateError < ClientError; end
 class TemplateEvaluationError < ClientError; end
+class InvalidBinaryError < ClientError; end

--- a/models/endpoint.rb
+++ b/models/endpoint.rb
@@ -1,6 +1,7 @@
 require 'dry-struct'
 require 'json'
 require 'erb'
+require 'base64'
 
 require_relative '../types'
 require_relative 'endpoint_request'
@@ -14,6 +15,7 @@ module Models
     attribute :verb, Types::String
     attribute :path, Types::String
     attribute :return_value, Types::Any
+    attribute :return_value_binary, Types::Bool.default(false)
     attribute :min_response_millis?, Types::Integer
     attribute :max_response_millis?, Types::Integer
     attribute :status_code, Types::Integer.default(200)
@@ -29,8 +31,18 @@ module Models
       raise TemplateEvaluationError.new(e.message)
     end
 
+    def return_value_binary
+      Base64.decode64(return_value)
+    rescue StandardError => e
+      raise InvalidBinaryError.new(e.message)
+    end
+
     def name
       "#{verb} #{path}"
+    end
+
+    def return_value_binary?
+      self[:return_value_binary]
     end
 
     def self.build(obj, id: nil)

--- a/models/endpoint_request.rb
+++ b/models/endpoint_request.rb
@@ -11,6 +11,7 @@ module Models
     attribute :verb, Types::String
     attribute :path, Types::String
     attribute :return_value, Types::Any
+    attribute :return_value_binary, Types::Bool.default(false)
     attribute :min_response_millis?, Types::Integer
     attribute :max_response_millis?, Types::Integer
     attribute :status_code, Types::Integer.default(200)


### PR DESCRIPTION
1. add attribute return_value_binary to indicate if the return value is binary
2. add a method that decodes the data from base64 to binary